### PR TITLE
bugfix: make -y 0 work as documented

### DIFF
--- a/csvtable
+++ b/csvtable
@@ -23,7 +23,7 @@ GetOptions(
 my $ok = can_load( modules => {'Unicode::GCString' => undef});
 
 # number of lines to determine maximum field width
-my $max_lines = $opt{y} || 1000;
+my $max_lines = $opt{y} // 1000;
 Usage() if $opt{h};
 
 my $fh;


### PR DESCRIPTION
Before the fix -y 0 worked just like -y 1000.

Note that defined-or is used which increases the minimum perl version to 5.10. If this is a problem, then the fix needs to be done differently.